### PR TITLE
Block all scoring when either player has won

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -113,8 +113,7 @@ function App() {
 
   const addPoint = (player: number, points: number) => {
     const current = stateRef.current;
-    if (player === 1 && current.player1Score >= current.matchLength) return;
-    if (player === 2 && current.player2Score >= current.matchLength) return;
+    if (current.player1Score >= current.matchLength || current.player2Score >= current.matchLength) return;
 
     if (player === 1) {
       const newScore = player1Score + points;


### PR DESCRIPTION
Closes #9

## Bug

After winning a match and dismissing the win Alert with Cancel, the losing player could still have their score increased by tapping their panel.

## Root cause

The overflow guard only checked the *tapped* player's own score:
```tsx
if (player === 1 && current.player1Score >= current.matchLength) return;
if (player === 2 && current.player2Score >= current.matchLength) return;
```
So if player 1 won, player 2's guard (`player2Score >= matchLength`) was still false.

## Fix

```tsx
if (current.player1Score >= current.matchLength || current.player2Score >= current.matchLength) return;
```

If either player has reached matchLength, no more scoring is allowed. Decreasing via long press remains unrestricted — that's the entire point of the Cancel button (correct a mistaken score that led to the win).