### PR TITLE
Lighten coil binder color in light mode

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -39,7 +39,7 @@ const LIGHT = {
   matchLabel:       '#888888',
   matchNumber:      '#111111',
   coilBg:           '#f0ede8',
-  coilBorder:       '#3c3c3e',
+  coilBorder:       '#b0aeab',
   hintText:         '#6e6b68',
   statusBar:        'dark-content' as const,
   shadowOpacity:    0.18,


### PR DESCRIPTION
## Summary
- Changes coil binding border color in light mode from near-black (`#3c3c3e`) to a warm light gray (`#b0aeab`)
- Dark mode is unchanged

## Test plan
- [ ] Verify coil binders appear lighter gray in light mode
- [ ] Verify coil binders are unchanged in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the coil border color in light theme to enhance visual appearance and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->